### PR TITLE
Fixed Shader Validation Error

### DIFF
--- a/PyIGL_viewer/shaders/per_vertex_color.frag
+++ b/PyIGL_viewer/shaders/per_vertex_color.frag
@@ -1,8 +1,8 @@
 #version 330
 
-in vec4 color;
+in vec3 color;
 
-out vec4 outputColor;
+out vec3 outputColor;
 void main()
 {
     outputColor = color;


### PR DESCRIPTION
There was an issue running the examples that was pointed out by this [issue](https://github.com/sunreef/PyIGL_viewer/issues/1#issue-1158458544). 
I simply turned off validation of the shader program to reveal the true problem was using varying color widths across shaders (vec3 vs vec4). This change corrects the problem.